### PR TITLE
Dev

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,3 @@
-# Notice
-
-This repository is moved to https://github.com/tkestack/presto-on-k8s-operator 
-New features、bugfix and long-term support will be suppored at there.
-
 ## Introduction
 
 This repo is used to create presto cluster in Kubernetes.

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,8 @@
+# Notice
+
+This repository is moved to https://github.com/tkestack/presto-on-k8s-operator 
+New features、bugfix and long-term support will be suppored at there.
+
 ## Introduction
 
 This repo is used to create presto cluster in Kubernetes.

--- a/controllers/reconciler.go
+++ b/controllers/reconciler.go
@@ -103,8 +103,13 @@ func (reconciler *ClusterReconciler) reconcileDeployment(
 	}
 
 	if desiredDeployment != nil && inspectedDeployment != nil {
+		if *desiredDeployment.Spec.Replicas != *inspectedDeployment.Spec.Replicas {
+			log.Info("Replicas changed",
+				"old replicas", *inspectedDeployment.Spec.Replicas,
+				"new replicas", *desiredDeployment.Spec.Replicas)
+			return reconciler.updateDeployment(desiredDeployment, component)
+		}
 		log.Info("Deployment already exists, no action")
-		return reconciler.updateDeployment(desiredDeployment, component)
 	}
 
 	if desiredDeployment == nil && inspectedDeployment != nil {


### PR DESCRIPTION
Update deployment when needed.
We only support to update the counts of the presto workers, so we only compare the deployment.Spec.Replicas and decide to whether to update the deployment.  Otherwise, in some cases, the deployment will be updated unexpected, for example, 
add the `map` of  catalogProperties to the volumenmount by using `for` but not sort the key of the `map`.